### PR TITLE
Mono Developer Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@ _ReSharper.*
 *.suo
 *.cache
 ~$*
-push.bat
+
+*.userprefs
+*.pidb
+test-results


### PR DESCRIPTION
Small commit to ignore MonoDevelop artifacts.  Also removed a duplicate entry for push.bat, there was already an entry at the top of the file.
