### PR TITLE
Minor improvement to HtmlTag.cs

### DIFF
--- a/src/HtmlTags.Testing/HtmlTagTester.cs
+++ b/src/HtmlTags.Testing/HtmlTagTester.cs
@@ -16,6 +16,18 @@ namespace HtmlTags.Testing
 
             tag.ToString().ShouldEqual("<span id=\"id\">");
         }
+        
+        [Test]
+        public void has_closing_tag_by_default()
+        {
+           new HtmlTag("div").HasClosingTag().ShouldBeTrue();
+        }
+        
+        [Test]
+        public void when_no_closing_tag_then_has_is_false()
+        {
+            new HtmlTag("div").NoClosingTag().HasClosingTag().ShouldBeFalse();
+        }
 
         [Test]
         public void write_next_if_it_exists()

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -315,7 +315,7 @@ namespace HtmlTags
 
             _children.Each(x => x.writeHtml(html));
 
-            if (!_ignoreClosingTag)
+            if (HasClosingTag())
             {
                 html.RenderEndTag();
             }
@@ -455,6 +455,10 @@ namespace HtmlTags
             return this;
         }
 
+        public bool HasClosingTag()
+        {
+            return !_ignoreClosingTag;
+        }
 
         public HtmlTag WrapWith(string tag)
         {


### PR DESCRIPTION
We utilize HtmlTag as a part of wrapping elements in a CMS - due to HtmlTag being able to render without a closing tag we need to accommodate for this in our wrapping mechanism.
