### PR TITLE
placing tfoot above tbody in TableTag, per html 4 spec

### DIFF
--- a/src/HtmlTags.Testing/TableTagTester.cs
+++ b/src/HtmlTags.Testing/TableTagTester.cs
@@ -169,8 +169,8 @@ namespace HtmlTags.Testing
             string captionTag = string.IsNullOrEmpty(caption)
                                     ? string.Empty
                                     : string.Format("<caption>{0}</caption>", caption);
-            return string.Format("<table>{0}<thead>{1}</thead><tbody>{2}</tbody>{3}</table>",
-                captionTag, theadContents, tbodyContents, tfoot);
+            return string.Format("<table>{0}<thead>{1}</thead>{2}<tbody>{3}</tbody></table>",
+                captionTag, theadContents, tfoot, tbodyContents);
         }
     }
 }

--- a/src/HtmlTags/TableTag.cs
+++ b/src/HtmlTags/TableTag.cs
@@ -7,11 +7,13 @@ namespace HtmlTags
     {
         private readonly HtmlTag _body;
         private readonly HtmlTag _header;
+        private readonly HtmlTag _footer;
 
         public TableTag()
             : base("table")
         {
             _header = new HtmlTag("thead", this);
+            _footer = new HtmlTag("tfoot", this).Render(false);
             _body = new HtmlTag("tbody", this);
         }
 
@@ -65,15 +67,8 @@ namespace HtmlTags
 
         public TableTag AddFooterRow(Action<TableRowTag> configure)
         {
-            var footer = Children.FirstOrDefault(x => x.TagName() == "tfoot");
-            if (footer == null)
-            {
-                footer = new HtmlTag("tfoot");
-                Append(footer);
-            }
-
-            configure(footer.Add<TableRowTag>());
-
+            _footer.Render(true);
+            configure(_footer.Add<TableRowTag>());
             return this;
         }
 


### PR DESCRIPTION
[Fixed my use of branches (thanks, Josh), resubmitting this pull request]

The way I'm reading the spec, in HTML 4, the tfoot had to come before the tbody. In HTML5, it can go in either spot. Sources:
http://www.w3.org/TR/html4/struct/tables.html#h-11.2.3
http://www.w3.org/TR/html5/tabular-data.html#the-tfoot-element

This change puts the tfoot in that spot, but renders it only if you've chosen to add a footer row. Please consider, though, if there could be side-effects from the way I implemented this. For example, there's now an extra item in the TableTag.Children collection--would anyone be relying on table.Children[1] to contain the tbody?
