### PR TITLE
HtmlDocument test coverage

### DIFF
--- a/src/HtmlTags.Testing/HtmlDocumentTester.cs
+++ b/src/HtmlTags.Testing/HtmlDocumentTester.cs
@@ -84,12 +84,6 @@ namespace HtmlTags.Testing
         }
 
         [Test]
-        public void to_compacted_returns_the_html_string()
-        {
-            document.ToCompacted().ShouldEqual(document.ToString());
-        }
-
-        [Test]
         public void add_javascript()
         {
             document.AddJavaScript(@"

--- a/src/HtmlTags/HtmlDocument.cs
+++ b/src/HtmlTags/HtmlDocument.cs
@@ -134,12 +134,6 @@ namespace HtmlTags
             }
         }
 
-        public string ToCompacted()
-        {
-            var returnValue = DocType + Environment.NewLine + _top;
-            return substitute(returnValue);
-        }
-
         private string substitute(string value)
         {
             foreach (var alteration in _alterations)


### PR DESCRIPTION
This change also deletes the HtmlDocument.ToCompacted method, which was no longer different from HtmlDocument.ToString.
