### PR TITLE
HtmlDocument's script and style tags

### DIFF
--- a/src/HtmlTags.Testing/HtmlDocumentTester.cs
+++ b/src/HtmlTags.Testing/HtmlDocumentTester.cs
@@ -71,8 +71,7 @@ namespace HtmlTags.Testing
         [Test]
         public void add_attributes_to_style_tag()
         {
-            document.AddStyle("p { display: block; }");
-            document.Last.Attr("media", "screen");
+            document.AddStyle("p { display: block; }").Attr("media", "screen");
             document.ToString().ShouldContain("</title><style media=\"screen\">p { display: block; }</style></head>");
         }
 
@@ -88,8 +87,7 @@ namespace HtmlTags.Testing
         public void reference_external_stylesheet_and_override_attributes()
         {
             document.ReferenceStyle("main.css");
-            document.ReferenceStyle("print.css");
-            document.Last.Attr("media", "print");
+            document.ReferenceStyle("print.css").Attr("media", "print");
             document.ToString().ShouldContain(
                 String.Format("{0}{1}{2}{3}",
                               "</title>",
@@ -132,8 +130,7 @@ alert('world');
         [Test]
         public void add_attributes_to_script_tag()
         {
-            document.AddJavaScript("var today;");
-            document.Last.Attr("defer", "true");
+            document.AddJavaScript("var today;").Attr("defer", "true");
             var expected = String.Format("</title><script type=\"text/javascript\" defer=\"true\">{0}var today;{0}</script></head>", Environment.NewLine);
             document.ToString().ShouldContain(expected);
         }
@@ -157,8 +154,7 @@ alert('world');
         public void reference_javascript_file_and_override_attributes()
         {
             document.ReferenceJavaScriptFile("nav.js");
-            document.ReferenceJavaScriptFile("biz.js");
-            document.Last.Attr("type", "text/vbscript");
+            document.ReferenceJavaScriptFile("biz.js").Attr("type", "text/vbscript");
             document.ToString().ShouldContain(
                 String.Format("{0}{1}{2}{3}",
                 "</title>",
@@ -226,6 +222,30 @@ alert('world');
 
             document.Push("p");
 
+            document.Last.TagName().ShouldEqual("p");
+        }
+
+        [Test]
+        public void adding_styles_does_not_alter_the_Last_property()
+        {
+            document.Add("p");
+            
+            document.AddStyle("font-weight: bold;");
+            document.Last.TagName().ShouldEqual("p");
+
+            document.ReferenceStyle("my.css");
+            document.Last.TagName().ShouldEqual("p");
+        }
+
+        [Test]
+        public void adding_scripts_does_not_alter_the_Last_property()
+        {
+            document.Add("p");
+
+            document.AddJavaScript("alert('hi');");
+            document.Last.TagName().ShouldEqual("p");
+
+            document.ReferenceJavaScriptFile("my.js");
             document.Last.TagName().ShouldEqual("p");
         }
 

--- a/src/HtmlTags/HtmlDocument.cs
+++ b/src/HtmlTags/HtmlDocument.cs
@@ -143,40 +143,38 @@ namespace HtmlTags
             return substitute(value);
         }
 
-        public void AddStyle(string styling)
+        public HtmlTag AddStyle(string styling)
         {
             var key = Guid.NewGuid().ToString();
-            Last = _head.Add("style").Text(key);
-
             _alterations.Add(html => html.Replace(key, styling));
+            return _head.Add("style").Text(key);
         }
 
-        public void AddJavaScript(string javascript)
+        public HtmlTag AddJavaScript(string javascript)
         {
-            AddScript("text/javascript", javascript);
+            return AddScript("text/javascript", javascript);
         }
 
-        public void AddScript(string scriptType, string scriptContents)
+        public HtmlTag AddScript(string scriptType, string scriptContents)
         {
             var key = Guid.NewGuid().ToString();
-            Last = _head.Add("script").Attr("type", scriptType).Text(key);
-
             _alterations.Add(html => html.Replace(key, Environment.NewLine + scriptContents + Environment.NewLine));
+            return _head.Add("script").Attr("type", scriptType).Text(key);
         }
 
-        public void ReferenceJavaScriptFile(string path)
+        public HtmlTag ReferenceJavaScriptFile(string path)
         {
-            ReferenceScriptFile("text/javascript", path);
+            return ReferenceScriptFile("text/javascript", path);
         }
 
-        public void ReferenceScriptFile(string scriptType, string path)
+        public HtmlTag ReferenceScriptFile(string scriptType, string path)
         {
-            Last = _head.Add("script").Attr("type", scriptType).Attr("src", path);
+            return _head.Add("script").Attr("type", scriptType).Attr("src", path);
         }
 
-        public void ReferenceStyle(string path)
+        public HtmlTag ReferenceStyle(string path)
         {
-            Last = _head.Add("link")
+            return _head.Add("link")
                 .Attr("media", "screen")
                 .Attr("href", path)
                 .Attr("type", "text/css")


### PR DESCRIPTION
This change grants more flexibility over how HtmlDocument renders attributes in the script and style tags. 

The Add\* and Reference\* methods that create those tags now return the tag they just created, so that you can set attributes on it, as in:
document.ReferenceStyle("print.css").Attr("media", "print");

New AddScript and ReferenceScriptFile methods let you specify the script type, so that you can use types other than text/javascript. (The existing javascript-focused methods remain.)

The rendered script tag will no longer contain the language attribute, which is deprecated in favor of the type attribute. (However, because of the above change to the Last property, you could still set that.) Source:
http://www.w3.org/TR/html4/interact/scripts.html#h-18.2.1
http://www.w3.org/TR/html5/scripting-1.html#script
