### PR TITLE
Changing the accessibility of HtmlTag.writeHtml(..)

### DIFF
--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -391,7 +391,7 @@ namespace HtmlTags
             return _shouldRender && _isAuthorized;
         }
 
-        private void writeHtml(HtmlTextWriter html)
+        protected virtual void writeHtml(HtmlTextWriter html)
         {
             if (!WillBeRendered()) return;
 


### PR DESCRIPTION
We needed to be able to override how the HtmlTag base class renders markup, in order to support the concept of a non-rendering container tag; a "tag" that renders all its children, but does not render itself. In many ways, it's similar to how `<text>` works in Razor.

Anyway, I changed the accessibility of the private method `writeHtml` to protected virtual to allow us to override the implementation in our class.

I'm not entirely sure what your naming/casing scheme is for protected methods, so I left it unchanged.
