### PR TITLE
Made HtmlTags build and run tests on Mono. All tests green on Mono/Win :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ _ReSharper.*
 *.pidb
 test-results
 src/packages
+results

--- a/rakefile.rb
+++ b/rakefile.rb
@@ -25,7 +25,6 @@ props = { :stage => File.expand_path("build"), :stage35 => File.expand_path("bui
 
 desc "**Default**, compiles and runs tests"
 task :default => [:compile, :unit_test, :stage]
-#task :default => [:compile, :unit_test, :stage, "fx35:compile", "fx35:unit_test", "fx35:stage"]
 task :ci => [:update_all_dependencies, :default, :history, :publish]
 
 desc "Update the version information for the build"
@@ -90,14 +89,13 @@ def copyOutputFiles(fromDir, filePattern, outDir)
   } 
 end
 
-desc "Run unit tests"
-nunit :unit_test do |nunit|
-    nunit.command = 'lib/nunit/nunit-console.exe'
-    nunit.assemblies = ["src/HtmlTags.Testing/bin/#{COMPILE_TARGET}/HtmlTags.Testing.dll"]
 
-#  runner = NUnitRunner.new :compilemode => COMPILE_TARGET, :source => 'src'
-#  runner.executeTests ['HtmlTags.Testing']
+desc "Runs unit tests"
+task :unit_test => :compile do
+  runner = NUnitRunner.new :compilemode => COMPILE_TARGET, :source => 'src', :platform => 'x86'
+  runner.executeTests ['HtmlTags.Testing']
 end
+
 
 task :stage do
   Dir.glob "src/HtmlTags/bin/#{COMPILE_TARGET}/HtmlTags.*" do |f|

--- a/src/HtmlTags.Testing/HtmlDocumentTester.cs
+++ b/src/HtmlTags.Testing/HtmlDocumentTester.cs
@@ -118,13 +118,13 @@ namespace HtmlTags.Testing
         [Test]
         public void add_javascript()
         {
-            document.AddJavaScript(@"
-alert('hello');
-alert('world');
-");
+            var script = String.Format("{0}alert('hello');{0}alert('world');{0}", Environment.NewLine);
+            document.AddJavaScript(script);
+			
             var expected = String.Format(
                 "</title><script type=\"text/javascript\">{0}{0}alert('hello');{0}alert('world');{0}{0}</script></head>",
                 Environment.NewLine);
+            
             document.ToString().ShouldContain(expected);
         }
 

--- a/src/HtmlTags.Testing/HtmlTagTester.cs
+++ b/src/HtmlTags.Testing/HtmlTagTester.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FubuCore;
 using FubuTestingSupport;
 using NUnit.Framework;
+using System.Text;
 
 namespace HtmlTags.Testing
 {
@@ -63,9 +64,12 @@ namespace HtmlTags.Testing
             var tag = new HtmlTag("div");
             new HtmlTag("p", tag).Id("intro").Text("Once upon a midnight...");
             
-            tag.ToPrettyString().ShouldEqual(@"<div>
-  <p id=""intro"">Once upon a midnight...</p>
-</div>");
+            var expected = new StringBuilder();
+            expected.AppendLine("<div>");
+            expected.AppendLine(@"  <p id=""intro"">Once upon a midnight...</p>");
+            expected.Append("</div>");
+			
+            tag.ToPrettyString().ShouldEqual(expected.ToString());
         }
 
         [Test]

--- a/src/HtmlTags/HtmlTags.csproj
+++ b/src/HtmlTags/HtmlTags.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -24,7 +24,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <DocumentationFile>bin\Debug\HtmlTags.xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591;0419;1580</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -35,7 +35,7 @@
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <DocumentationFile>bin\Release\HtmlTags.xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591;0419;1580</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Fixed tests that used newline.
- Added ignore warnings for CS 0419 and CS 1580 to get around mono compiler
  raising errors with xml documentation "see cref" usage.
- Added results to gitignore
