### PR TITLE
Changing the default metadata suffix to __ 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -133,11 +133,11 @@ Or you can serialize an entire settings object in a single value on the server t
 
 Notice we're passing an instance of an object (EditableOptions) as the value of the "editable" metadata. This will render:
 
-    <div data-:="{&quot;editable&quot;:{&quot;MultiLine&quot;:false,&quot;MaxLength&quot;:20,&quot;InputType&quot;:&quot;date&quot;}}"></div>
+    <div data-__="{&quot;editable&quot;:{&quot;MultiLine&quot;:false,&quot;MaxLength&quot;:20,&quot;InputType&quot;:&quot;date&quot;}}"></div>
 
 You can then drive logic on the client using this data:
 
-    $.metadata.setType('attr', 'data-:'); //once on your page
+    $.metadata.setType('attr', 'data-__'); //once on your page
     var o = $("div").metadata();
     alert(o.MultiLine); // # false
     alert(o.MaxLength); // # 20

--- a/src/HtmlTags.Testing/HtmlTagTester.cs
+++ b/src/HtmlTags.Testing/HtmlTagTester.cs
@@ -882,12 +882,12 @@ namespace HtmlTags.Testing
             tag.MetaData("a", 1);
             tag.MetaData("b", "b-value");
 
-            tag.ToString().ShouldEqual("<div data-:=\"{&quot;a&quot;:1,&quot;b&quot;:&quot;b-value&quot;}\">text</div>");
+            tag.ToString().ShouldEqual("<div data-__=\"{&quot;a&quot;:1,&quot;b&quot;:&quot;b-value&quot;}\">text</div>");
 
             // now with another class
             tag.AddClass("class1");
 
-            tag.ToString().ShouldEqual("<div class=\"class1\" data-:=\"{&quot;a&quot;:1,&quot;b&quot;:&quot;b-value&quot;}\">text</div>");
+            tag.ToString().ShouldEqual("<div class=\"class1\" data-__=\"{&quot;a&quot;:1,&quot;b&quot;:&quot;b-value&quot;}\">text</div>");
         }
 
         [Test]
@@ -962,7 +962,7 @@ namespace HtmlTags.Testing
                 {
                     Display = "a",
                     Value = "1"
-                }).ToString().ShouldEqual("<div data-:=\"{&quot;listValue&quot;:{&quot;Display&quot;:&quot;a&quot;,&quot;Value&quot;:&quot;1&quot;}}\"></div>");
+                }).ToString().ShouldEqual("<div data-__=\"{&quot;listValue&quot;:{&quot;Display&quot;:&quot;a&quot;,&quot;Value&quot;:&quot;1&quot;}}\"></div>");
         }
     }
 
@@ -978,7 +978,7 @@ namespace HtmlTags.Testing
         [Test]
         public void metadataattribute_value_ends_with_a_colon_char_by_default()
         {
-            HtmlTag.MetadataAttribute.ShouldEqual("data-:");
+            HtmlTag.MetadataAttribute.ShouldEqual("data-__");
         }
 
         [Test]

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -299,15 +299,15 @@ namespace HtmlTags
         }
 
         /// <summary>
-        /// Stores multiple JSON-encoded key/value pairs in a the "data-:" attribute. Useful when used with the jquery.metadata plugin
+        /// Stores multiple JSON-encoded key/value pairs in a the "data-__" attribute. Useful when used with the jquery.metadata plugin
         /// </summary>
         /// <param name="key">The name of the stored value</param>
         /// <param name="value">The value to store</param>
-        /// <remarks>You need to configure the the jquery.metadata plugin to read from the data-: attribute.
+        /// <remarks>You need to configure the the jquery.metadata plugin to read from the data-__ attribute.
         /// Add the following line after you have loaded jquery.metadata.js, but before you use its metadata() method:
         /// <code>
         /// if ($.metadata) {
-        ///    $.metadata.setType('attr', 'data-:');
+        ///    $.metadata.setType('attr', 'data-__');
         /// }
         /// </code>
         /// </remarks>


### PR DESCRIPTION
IE 9 doesn't parse data-: properly.

Best not to default the library to a known bug
