### PR TITLE
added support for empty attributes

### DIFF
--- a/src/HtmlTags.Testing/HtmlTagTester.cs
+++ b/src/HtmlTags.Testing/HtmlTagTester.cs
@@ -322,16 +322,6 @@ namespace HtmlTags.Testing
         }
 
         [Test]
-        public void set_an_attribute_to_empty_string_should_remove_the_attribute()
-        {
-            var tag = new HtmlTag("div");
-            tag.Attr("name", "bill");
-            tag.HasAttr("name").ShouldBeTrue();
-            tag.Attr("name", "");
-            tag.HasAttr("name").ShouldBeFalse();
-        }
-
-        [Test]
         public void set_the_class_attribute_to_null_should_remove_all_classes()
         {
             var tag = new HtmlTag("div");
@@ -374,6 +364,28 @@ namespace HtmlTags.Testing
         public void retrieve_a_non_existing_attr_should_return_an_empty_string()
         {
             new HtmlTag("div").Attr("new").ShouldEqual(string.Empty);
+        }
+
+        [Test]
+        public void set_an_attribute_to_empty_string_should_not_remove_the_attribute() {
+            var tag = new HtmlTag("div");
+            tag.Attr("name", "bill");
+            tag.HasAttr("name").ShouldBeTrue();
+            tag.Attr("name", string.Empty);
+            tag.HasAttr("name").ShouldBeTrue();
+        }
+
+        [Test]
+        public void retrieve_an_empty_attr_should_return_an_empty_string() {
+            var tag = new HtmlTag("option");
+            tag.Attr("value", string.Empty);
+            tag.Attr("value").ShouldEqual(string.Empty);
+        }
+
+        [Test]
+        public void render_empty_attr() {
+            var tag = new HtmlTag("option").Attr("value", string.Empty);
+            tag.ToString().ShouldEqual("<option value=\"\"></option>");
         }
 
         //

--- a/src/HtmlTags/HtmlTag.cs
+++ b/src/HtmlTags/HtmlTag.cs
@@ -539,14 +539,18 @@ namespace HtmlTags
 
         private HtmlTag buildAttr(string attribute, object value, bool encode = true)
         {
-            if (value == null || value.Equals(string.Empty))
+            if (value == null)
+            {
+                return RemoveAttr(attribute);
+            }
+            if (value.Equals(string.Empty) && (isCssClassAttr(attribute) || isCssStyleAttr(attribute) || isMetadataAttr(attribute)))
             {
                 return RemoveAttr(attribute);
             }
             if (isCssClassAttr(attribute))
             {
                 AddClass(value.ToString());
-            }   
+            }
             else
             {
                 _htmlAttributes[attribute] = new HtmlAttribute(value.ToString(), encode);


### PR DESCRIPTION
There is a substantial difference (in some cases) between an empty attribute and no attribute. For example, &lt;option&gt;Some Text&lt;/option&gt; submits "Some Text" vs. &lt;option value=""&gt;Some Text&lt;/option&gt; submits "". Currently, the Data() method allows for "", and so should Attr().
