### PR TITLE
Increasing the default JavaScriptSerializer to handle large data.

### DIFF
--- a/src/HtmlTags.Testing/JsonUtilTester.cs
+++ b/src/HtmlTags.Testing/JsonUtilTester.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Text;
 using FubuTestingSupport;
 using NUnit.Framework;
@@ -35,10 +37,51 @@ namespace HtmlTags.Testing
 
             JsonUtil.Get<JsonUtilTarget>(bytes).Name.ShouldEqual("Jeremy");
         }
+
+        [Test]
+        public void get_by_bytes_large_data()
+        {
+            var guids = new List<Guid>();
+            for (var i = 0; i < 60000; i++)
+            {
+                 guids.Add(Guid.NewGuid());
+            }
+            var largeTarget = new JsonLargeUtilTarget
+            {
+                Guids = guids
+            };
+            var json = JsonUtil.ToJson(largeTarget);
+            var bytes = Encoding.Default.GetBytes(json);
+            JsonUtil.Get<JsonLargeUtilTarget>(bytes).Guids.Count.ShouldEqual(60000);
+        }
+
+        [Test]
+        public void can_handle_large_data_objects()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var guids = new List<Guid>();
+                for (var i = 0; i < 60000; i++)
+                {
+                    guids.Add(Guid.NewGuid());
+                }
+                var large = new JsonLargeUtilTarget
+                {
+                    Guids = guids
+                };
+                JsonUtil.ToJson(large).ShouldNotBeEmpty();
+            });
+        }
     }
 
     public class JsonUtilTarget
     {
         public string Name { get; set; }
     }
+
+    public class JsonLargeUtilTarget
+    {
+        public List<Guid> Guids { get; set; }
+    }
+
 }

--- a/src/HtmlTags/JsonUtil.cs
+++ b/src/HtmlTags/JsonUtil.cs
@@ -11,7 +11,11 @@ namespace HtmlTags
 #pragma warning disable 618,612
         public static string ToJson(object objectToSerialize)
         {
-            return new JavaScriptSerializer().Serialize(objectToSerialize);
+            var serializer = new JavaScriptSerializer
+            {
+                MaxJsonLength = int.MaxValue
+            };
+            return serializer.Serialize(objectToSerialize);
         }
 
         /// <summary>
@@ -22,6 +26,7 @@ namespace HtmlTags
         public static string ToUnsafeJson(object objectToSerialize)
         {
             var serializer = new JavaScriptSerializer();
+            serializer.MaxJsonLength = int.MaxValue;
             serializer.RegisterConverters(new JavaScriptConverter[]{new JavascriptFunctionConverter()});
             var output = serializer.Serialize(objectToSerialize);
             const string pattern = @"\{""__jsfunction"":""(?<function>\w+)""}";
@@ -30,7 +35,11 @@ namespace HtmlTags
 
         public static T Get<T>(string rawJson)
         {
-            return new JavaScriptSerializer().Deserialize<T>(rawJson);
+            var serializer = new JavaScriptSerializer
+            {
+                MaxJsonLength = int.MaxValue
+            };
+            return serializer.Deserialize<T>(rawJson);
         }
 
         public static T Get<T>(byte[] rawJson)
@@ -41,7 +50,11 @@ namespace HtmlTags
 
         public static object Get(string rawJson)
         {
-            return new JavaScriptSerializer().DeserializeObject(rawJson);
+            var serializer = new JavaScriptSerializer
+            {
+                MaxJsonLength = int.MaxValue
+            };
+            return serializer.DeserializeObject(rawJson);
         }
 
         public class JavascriptFunctionConverter : JavaScriptConverter


### PR DESCRIPTION
There are areas in the FubuMVC.IntegrationTesting and FubuMVC.Core that use the JsonUtil class. This class uses the default JavaScriptSerialization class and is not compatible with a large objects. The MaxJsonLength is being increased to int.MaxValue to avoid any errors.
